### PR TITLE
Connection direction

### DIFF
--- a/Manager/ConnectionManager.php
+++ b/Manager/ConnectionManager.php
@@ -34,9 +34,9 @@ class ConnectionManager implements ConnectionManagerInterface
      * 
      * @throws AlreadyConnectedException When connection from source to destination already exists
      */
-    public function connect(NodeInterface $source, NodeInterface $destination, $type)
+    public function connect(NodeInterface $source, NodeInterface $destination, $type, $direction = ConnectionInterface::DIRECTION_TWO_WAYS)
     {
-        $connection = $this->createConnection($source, $destination, $type);
+        $connection = $this->createConnection($source, $destination, $type, $direction);
         $this->getConnectionRepository()->update($connection);
 
         if ($this->dispatcher) {
@@ -113,11 +113,11 @@ class ConnectionManager implements ConnectionManagerInterface
     /**
      * {@inheritDoc}
      */
-    public function areConnected(NodeInterface $nodeA, NodeInterface $nodeB, array $filters = array())
+    public function areConnected(NodeInterface $nodeA, NodeInterface $nodeB, array $filters = array(), $direction = null)
     {
         $this->filterValidator->validateFilters($filters);
 
-        return $this->getConnectionRepository()->areConnected($nodeA, $nodeB, $filters);
+        return $this->getConnectionRepository()->areConnected($nodeA, $nodeB, $filters, $direction);
     }
     
     /**
@@ -185,9 +185,9 @@ class ConnectionManager implements ConnectionManagerInterface
      * @return \Kitano\ConnectionBundle\Model\ConnectionInterface
      * @throws \Kitano\ConnectionBundle\Exception\AlreadyConnectedException
      */
-    protected function createConnection(NodeInterface $source, NodeInterface $destination, $type)
+    protected function createConnection(NodeInterface $source, NodeInterface $destination, $type, $direction = ConnectionInterface::DIRECTION_TWO_WAYS)
     {
-        if ($this->areConnected($source, $destination, array('type' => $type))) {
+        if ($this->areConnected($source, $destination, array('type' => $type, 'direction' => $direction))) {
             throw new AlreadyConnectedException(
                 sprintf('Objects %s (%s) and %s (%s) are already connected',
                     get_class($source),

--- a/Manager/FilterValidator.php
+++ b/Manager/FilterValidator.php
@@ -46,7 +46,7 @@ class FilterValidator
         }
     }
 
-    public function setValidator(Validator $validator)
+    public function setValidator(Validator\LegacyValidator $validator)
     {
         $this->validator = $validator;
     }

--- a/Manager/FilterValidator.php
+++ b/Manager/FilterValidator.php
@@ -4,8 +4,9 @@ namespace Kitano\ConnectionBundle\Manager;
 
 use Kitano\ConnectionBundle\Exception\InvalidFilterException;
 
+use Kitano\ConnectionBundle\Model\ConnectionInterface;
+use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Validator;
-
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Type;
@@ -23,16 +24,23 @@ class FilterValidator
      */
     public function validateFilters(array &$filters)
     {
+        $direction = new Choice();
+        $direction->choices = array(
+            ConnectionInterface::DIRECTION_ONE_WAY,
+            ConnectionInterface::DIRECTION_TWO_WAYS
+        );
         $filterConstraint = new Collection(array(
-            'type' => array(
-                new NotBlank(),
-                new NotNull(),
-            ),
-            'depth' => new Type('integer'),
-        ));
+                'type' => array(
+                    new NotBlank(),
+                    new NotNull(),
+                ),
+                'direction' => $direction,
+                'depth' => new Type('integer'),
+            ));
 
         $filtersDefault = array(
-            'depth' => 1,
+            'direction' => ConnectionInterface::DIRECTION_TWO_WAYS,
+            'depth' => 1
         );
 
         $filters = array_merge($filtersDefault, $filters);

--- a/Model/ConnectionInterface.php
+++ b/Model/ConnectionInterface.php
@@ -4,6 +4,9 @@ namespace Kitano\ConnectionBundle\Model;
 
 interface ConnectionInterface
 {
+    const DIRECTION_ONE_WAY = 'one-way';
+    const DIRECTION_TWO_WAYS = 'two-ways';
+
     /**
      * Returns the Node from where the Connection (edge) start
      *

--- a/Repository/DoctrineMongoDBConnectionRepository.php
+++ b/Repository/DoctrineMongoDBConnectionRepository.php
@@ -88,16 +88,18 @@ class DoctrineMongoDBConnectionRepository extends DocumentRepository implements 
     {
         $qb = $this->createQueryBuilder('Connection');
 
-        $qb->addOr(
-            $qb->expr()
-                ->field("source")->references($nodeA)
-                ->field("destination")->references($nodeB)
-        )
-        ->addOr(
-            $qb->expr()
-                ->field("source")->references($nodeB)
-                ->field("destination")->references($nodeA)
-        ) ;
+        $sourceAExpr = $qb->expr()
+            ->field("source")->references($nodeA)
+            ->field("destination")->references($nodeB);
+        $sourceBExpr = $qb->expr()
+            ->field("source")->references($nodeB)
+            ->field("destination")->references($nodeA);
+
+        $qb->addOr($sourceAExpr);
+
+        if (!isset($filters['direction']) || $filters['direction'] == ConnectionInterface::DIRECTION_TWO_WAYS) {
+            $qb->addOr($sourceBExpr);
+        }
 
         if (array_key_exists('type', $filters)) {
             $qb->field('type')->equals($filters['type']);

--- a/Tests/Repository/DoctrineMongoDBConnectionRepositoryTest.php
+++ b/Tests/Repository/DoctrineMongoDBConnectionRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Kitano\ConnectionBundle\Tests\Repository;
 
+use Kitano\ConnectionBundle\Model\ConnectionInterface;
 use Kitano\ConnectionBundle\Repository\DoctrineMongoDBConnectionRepository;
 use Kitano\ConnectionBundle\Model\NodeInterface;
 use Kitano\ConnectionBundle\Tests\MongoDBTestCase;
@@ -195,6 +196,39 @@ class DoctrineMongoDBConnectionRepositoryTest extends MongoDBTestCase implements
         $this->assertTrue($this->repository->areConnected($node1, $node3, array('type' => self::CONNECTION_TYPE)));
         $this->assertTrue($this->repository->areConnected($node3, $node1, array('type' => self::CONNECTION_TYPE)));
         $this->assertFalse($this->repository->areConnected($node2, $node3, array('type' => self::CONNECTION_TYPE)));
+    }
+
+    /**
+     * @group odm
+     */
+    public function testAreConnectedOneWay()
+    {
+        $node1 = new Node(455);
+        $node2 = new Node(4412);
+        $node3 = new Node(4244);
+
+        $this->getDocumentManager()->persist($node1);
+        $this->getDocumentManager()->persist($node2);
+        $this->getDocumentManager()->persist($node3);
+        $this->getDocumentManager()->flush();
+
+        $connection1 = $this->createConnection($node1, $node2, self::CONNECTION_TYPE, ConnectionInterface::DIRECTION_ONE_WAY);
+        $connection2 = $this->createConnection($node2, $node1, self::CONNECTION_TYPE, ConnectionInterface::DIRECTION_ONE_WAY);
+        $connection3 = $this->createConnection($node1, $node3, self::CONNECTION_TYPE, ConnectionInterface::DIRECTION_ONE_WAY);
+
+        $this->repository->update($connection1);
+        $this->repository->update($connection2);
+        $this->repository->update($connection3);
+
+        $filters = array(
+            'type' => self::CONNECTION_TYPE,
+            'direction' => ConnectionInterface::DIRECTION_ONE_WAY
+        );
+        $this->assertTrue($this->repository->areConnected($node1, $node2, $filters));
+        $this->assertTrue($this->repository->areConnected($node2, $node1, $filters));
+        $this->assertTrue($this->repository->areConnected($node1, $node3, $filters));
+        $this->assertFalse($this->repository->areConnected($node2, $node3, $filters));
+        $this->assertFalse($this->repository->areConnected($node3, $node1, $filters));
     }
 
     /**


### PR DESCRIPTION
If userA follows userB, trying to add userB as a follower of userA throws an exception as the users are already connected. I can see the value of keeping bidirectional connections (where whether a node is the source or the destination doesn't matter), for friend connections, for example, but one way connections should also be possible. I've kept the default behaviour to two-ways connections in order not to introduce backward incompatibilities. Also, there might be more changes needed, for now only the Manager::connect and Repository::areConnected are aware of the direction of the connection.
